### PR TITLE
Add CLI skeleton for heart attack script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi
+
+echo "Setup complete"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.ruff_cache/
+outputs/

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,1 +1,3 @@
 
+
+* 2025-07-07: added skeleton src/heart_attack_prediction.py parsing --data and --out and printing placeholder. Reason: initial CLI entry point per TODO.

--- a/TODO.md
+++ b/TODO.md
@@ -76,3 +76,6 @@ Copy
 
 ## 6  Out‑of‑scope for this Codex run
 Slides and the written report will be produced manually by the Presentation and Documentation roles.
+
+## Completed tasks
+* [x] CLI skeleton parses dataset and output path, prints placeholder.

--- a/src/heart_attack_prediction.py
+++ b/src/heart_attack_prediction.py
@@ -1,0 +1,28 @@
+import argparse
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Heart Attack Risk Prediction placeholder"
+    )
+    parser.add_argument(
+        "--data",
+        required=True,
+        help="Path to dataset CSV",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Directory to store outputs",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    print(f"Placeholder - dataset: {args.data}, output directory: {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add placeholder CLI in `src/heart_attack_prediction.py`
- record work in `NOTES.md`
- mark the task complete in `TODO.md`
- prepare environment script and gitignore

## Testing
- `bash .codex/setup.sh`
- `python src/heart_attack_prediction.py --data data/heart_attack_prediction_dataset.csv --out outputs/`
- `ruff check src tests`
- `black --check src tests`


------
https://chatgpt.com/codex/tasks/task_e_686b730bfac08325a92fe8049c15ba91