### PR TITLE
Add setup script and dependency list

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,1 +1,3 @@
 
+
+- 2025-07-07: Added .codex/setup.sh and requirements.txt to install pandas, scikit-learn, and matplotlib. Reason: create base environment as described in TODO setup stage.

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@ Copy
 
 *Feel free to adjust directory names if a clearer structure emerges, but keep the dataset path accurate (`data/…csv`).*
 
+Status (2025-07-07): setup script and requirements created. Next: implement pipeline skeleton in src/heart_attack_prediction.py.
 ---
 
 ## 1  Environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+scikit-learn
+matplotlib


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` that installs dependencies from requirements.txt
- list basic ML libs in requirements.txt
- log the new setup in NOTES
- mark the setup task in TODO as done with next action

## Testing
- `bash .codex/setup.sh`
- `python src/heart_attack_prediction.py --data data/heart_attack_prediction_dataset.csv --out outputs/` *(fails: file not found)*
- `ruff check src tests` *(fails: no such file)*
- `black --check src tests` *(fails: path does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686b730a993083259c9a40fc5af0f0d6