### PR TITLE
Clarify setup in AGENTS

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install Python packages if requirements.txt exists
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ that actively steer the agent.
 ## 1  Quick health‑check (runs each iteration)
 
 shell: |
-  # 1. Ensure the environment is ready (idempotent).
+  # 1. Set up Python environment (installs `requirements.txt` if present).
   bash .codex/setup.sh
 
   # 2. Execute the end‑to‑end pipeline.
@@ -47,7 +47,7 @@ shell: |
 | `src/heart_attack_prediction.py`            | End‑to‑end ML pipeline *you may decide to break it into several files)                  |
 | `data/heart_attack_prediction_dataset.csv`  | Raw dataset (read‑only)                 |
 | `outputs/`                                  | Metrics, plots, confusion matrix        |
-| `.codex/setup.sh`                           | Dependency installation                 |
+| `.codex/setup.sh`                           | Install packages from `requirements.txt` |
 | `README.md`                                 | Quick‑start instructions                |
 | `TODO.md` / `NOTES.md`                      | Work plan / engineering log (append‑only)|
 Original_assignment.md and .csv dataset are single sources of truth and are not to be changed.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,1 +1,2 @@
 
+- 2025-07-07: Updated AGENTS.md shell block to mention that `.codex/setup.sh` installs packages from `requirements.txt` and created this script.

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@ Copy
 ## 1  Environment
 * Use **Python** (already on Codex base image).
 * If additional packages are required, let Codex generate a `requirements.txt` and ensure `.codex/setup.sh` installs them (`pip install -r requirements.txt`).
+- [x] Initialise `.codex/setup.sh` to install from `requirements.txt`.
 
 ---
 


### PR DESCRIPTION
## Summary
- note that `.codex/setup.sh` installs packages from `requirements.txt`
- mention this in the quick health-check shell block
- provide the setup script
- log the update in NOTES
- mark the task done in TODO

## Testing
- `bash .codex/setup.sh`
- `python src/heart_attack_prediction.py --data data/heart_attack_prediction_dataset.csv --out outputs/` *(fails: file not found)*
- `if command -v ruff >/dev/null 2>&1; then ruff check src tests; fi` *(fails: paths missing)*
- `if command -v black >/dev/null 2>&1; then black --check src tests; fi` *(fails: paths missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b731178f08325a1de6ac1c0a09707