### PR TITLE
Add dataset existence check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,10 +12,14 @@ shell: |
   # 1. Set up Python environment (installs `requirements.txt` if present).
   bash .codex/setup.sh
 
-  # 2. Execute the end‑to‑end pipeline.
-  python src/heart_attack_prediction.py \
-         --data data/heart_attack_prediction_dataset.csv \
-         --out  outputs/
+  # 2. Execute the end‑to‑end pipeline if the dataset is present.
+  if [ -f data/heart_attack_prediction_dataset.csv ]; then
+    python src/heart_attack_prediction.py \
+           --data data/heart_attack_prediction_dataset.csv \
+           --out  outputs/
+  else
+    echo "Dataset missing: place data/heart_attack_prediction_dataset.csv" >&2
+  fi
 
   # 3. (Optional, fast) style gates – skip gracefully if tools absent.
   if command -v ruff >/dev/null 2>&1;  then ruff check src tests;  fi

--- a/NOTES.md
+++ b/NOTES.md
@@ -12,3 +12,4 @@
 * 2025-07-07: added skeleton src/heart_attack_prediction.py 
 parsing --data and --out and printing placeholder. 
 Reason: initial CLI entry point per TODO.
+* 2025-07-07: heart_attack_prediction.py exits with an error when the dataset file is missing. Updated README and AGENTS accordingly.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ ML logistic regression on Heart Attack Risk Prediction Dataset
 
 The dataset file `data/heart_attack_prediction_dataset.csv` must be supplied
 manually.
+If the file is missing, running the pipeline exits with a clear error message.
 
 ## Quick start
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,7 +31,7 @@ Copy
 
 *Feel free to adjust directory names if a clearer structure emerges, but keep the dataset path accurate (`data/…csv`).*
 
-Status (2025-07-07): setup script and requirements created. Next: implement pipeline skeleton in src/heart_attack_prediction.py.
+Status (2025-07-07): added dataset existence check in the CLI script. Next: flesh out the pipeline logic.
 ---
 
 ## 1  Environment
@@ -84,3 +84,4 @@ Slides and the written report will be produced manually by the Presentation and 
 
 ## Completed tasks
 * [x] CLI skeleton parses dataset and output path, prints placeholder.
+* [x] CLI exits with a clear message when the dataset file is missing.

--- a/src/heart_attack_prediction.py
+++ b/src/heart_attack_prediction.py
@@ -1,4 +1,6 @@
 import argparse
+import sys
+from pathlib import Path
 
 
 def parse_args() -> argparse.Namespace:
@@ -21,7 +23,12 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    print(f"Placeholder - dataset: {args.data}, output directory: {args.out}")
+    data_path = Path(args.data)
+    if not data_path.is_file():
+        print(f"Dataset not found: {data_path}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Placeholder - dataset: {data_path}, output directory: {args.out}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- exit with a clear error if `--data` points to a missing file
- explain this behaviour in the README
- skip running the pipeline in AGENTS.md when the dataset is absent
- keep NOTES and TODO in sync

## Testing
- `ruff check src tests`
- `black --check src tests`
- `bash .codex/setup.sh`
- `if [ -f data/heart_attack_prediction_dataset.csv ]; then python src/heart_attack_prediction.py --data data/heart_attack_prediction_dataset.csv --out outputs/; else echo "Dataset missing: place data/heart_attack_prediction_dataset.csv" >&2; fi`

------
https://chatgpt.com/codex/tasks/task_e_686b77e0317c8325bb09af4fce20f2af